### PR TITLE
Adaption for complying with SPDX identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "homepage": "http://vfs.bovigo.org/",
     "description": "Virtual file system to mock the real file system in unit tests.",
-    "license": "BSD",
+    "license": "BSD-3-Clause",
     "require": {
         "php": ">=5.3.0"
     },


### PR DESCRIPTION
I currently oversee the licenses used in our projects

It would make sense to update the file as suggested in order to comply with the license identifiers as listed by SPDX
http://spdx.org/licenses/

Reasoning:
"BSD" could imply various licenses, not all of which are compatible with the GPL. 
For details e.g. see http://www.gnu.org/philosophy/bsd.html