### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/docs                               export-ignore
+/examples                           export-ignore
+/src/test                           export-ignore
+/.coveralls.yml                     export-ignore
+/.gitattributes                     export-ignore
+/.gitignore                         export-ignore
+/.travis.yml                        export-ignore
+/phpdoc.dist.xml                    export-ignore
+/phpunit.xml.dist                   export-ignore


### PR DESCRIPTION
Using export-ignore statements the overall size of the project can be reduced for archives.

See PR #99.