### PR TITLE
Support nested string-based directory retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.4.0 (2014-??-??)
+1.4.0 (2014-09-14)
 ------------------
 
    * implemented #85: Added support for emulating block devices in the virtual filesystem, feature provided by Harris Borawski

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "mikey179/vfsStream",
     "type": "library",
     "homepage": "http://vfs.bovigo.org/",
+    "description": "Virtual file system to mock the real file system in unit tests.",
     "license": "BSD",
     "require": {
         "php": ">=5.3.0"

--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -316,23 +316,32 @@ class vfsStream
      * @param   int     $permissions  permissions of directory to create
      * @return  vfsStreamDirectory
      */
-    public static function newDirectory($name, $permissions = null)
-    {
-        if ('/' === $name{0}) {
-            $name = substr($name, 1);
-        }
+	public static function newDirectory($name, $permissions = null)
+	{
+		$atRoot = ('/' === $name{0});
+		if ($atRoot) {
+			$name = substr($name, 1);
+		}
 
-        $firstSlash = strpos($name, '/');
-        if (false === $firstSlash) {
-            return new vfsStreamDirectory($name, $permissions);
-        }
+		$firstSlash = strpos($name, '/');
+		if (false === $firstSlash) {
+			return new vfsStreamDirectory($name, $permissions);
+		}
 
-        $ownName   = substr($name, 0, $firstSlash);
-        $subDirs   = substr($name, $firstSlash + 1);
-        $directory = new vfsStreamDirectory($ownName, $permissions);
-        self::newDirectory($subDirs, $permissions)->at($directory);
-        return $directory;
-    }
+		$ownName   = substr($name, 0, $firstSlash);
+		$subDirs   = substr($name, $firstSlash + 1);
+		$directory = new vfsStreamDirectory($ownName, $permissions);
+
+		if($atRoot){
+			$root = vfsStreamWrapper::getRoot();
+			if(!is_null($root)){
+				$directory->at($root);
+			}
+		}
+
+		self::newDirectory($subDirs, $permissions)->at($directory);
+		return $directory;
+	}
 
     /**
      * returns a new block with the given name

--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -195,6 +195,9 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
 	 */
 	public function getChildByPath($path)
 	{
+		if(!is_string($path)){
+			throw new vfsStreamException("Unexpected argument, path as string only supported");
+		}
 		$aPath = explode('/', $path);
 		$child = $this->getChild($aPath[0]);
 		array_shift($aPath);
@@ -202,7 +205,7 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
 		if($aPath){
 			foreach($aPath as $childName){
 				$tmp = $child->getChild($childName);
-				if($tmp){
+				if(!is_null($tmp)){
 					$child = $tmp;
 				}
 				else{

--- a/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
@@ -210,6 +210,39 @@ class vfsStreamDirectoryTestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->dir->sizeSummarized());
     }
 
+	/**
+	 * @test
+	 */
+	public function getChildByPath(){
+		$subdir = new vfsStreamDirectory('child');
+		$subdir->addChild(new vfsStreamDirectory('grandChild'));
+		$this->dir->addChild($subdir);
+		$result = $this->dir->getChildByPath('child/grandChild');
+
+		$this->assertEquals('grandChild', $result->getName());
+		$this->assertEquals(0, $result->size());
+	}
+
+	/**
+	 * @test
+	 * @expectedException  org\bovigo\vfs\vfsStreamException
+	 */
+	public function getChildByPath_notFound(){
+		$subdir = new vfsStreamDirectory('child');
+		$this->dir->addChild($subdir);
+		$this->dir->getChildByPath('child/grandChild');
+	}
+
+	/**
+	 * @test
+	 * @expectedException  org\bovigo\vfs\vfsStreamException
+	 */
+	public function getChildByPath_notStringArg(){
+		$subdir = new vfsStreamDirectory('child');
+		$this->dir->addChild($subdir);
+		$this->dir->getChildByPath(false);
+	}
+	
     /**
      * dd
      *


### PR DESCRIPTION
I think there should be a shorter syntax for getting child from deep level, so that its possible to navigate not with..
```
$rootDir = vfsStreamWrapper::getRoot();
$rootDir->getChild('library')->getChild('1')->getChild('1')->getChild('1')->getChild('bb2075d7d7023ebd5929f6a3f4c4d499')
```
But more naturally, like this..
```
$rootDir->getChildByPath('library/1/1/1/bb2075d7d7023ebd5929f6a3f4c4d499')
```