### PR TITLE
Add vfsStreamWrapper::unregister() to unregister the URL wrapper.

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -116,6 +116,32 @@ class vfsStreamWrapper
     }
 
     /**
+     * Unregisters a previously registered URL wrapper for the vfs scheme.
+     * 
+     * If this stream wrapper wasn't registered, the method returns silently.
+     *
+     * If unregistering fails, or if the URL wrapper for vfs:// was not
+     * registered with this class, a vfsStreamException will be thrown.
+     * 
+     * @throws vfsStreamException
+     */
+    public static function unregister()
+    {
+        if (!self::$registered) {
+            if (in_array(vfsStream::SCHEME, stream_get_wrappers())) {
+                throw new vfsStreamException('The URL wrapper for the protocol ' . vfsStream::SCHEME . ' was not registered with this version of vfsStream.');
+            }
+            return;
+        }
+
+        if (!@stream_wrapper_unregister(vfsStream::SCHEME)) {
+            throw new vfsStreamException('Failed to unregister the URL wrapper for the ' . vfsStream::SCHEME . ' protocol.');
+        }
+
+        self::$registered = false;
+    }
+
+    /**
      * sets the root content
      *
      * @param   vfsStreamContainer  $root

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperUnregisterTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperUnregisterTestCase.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package  org\bovigo\vfs
+ */
+namespace org\bovigo\vfs;
+
+/**
+ * Test for org\bovigo\vfs\vfsStreamWrapper.
+ */
+class vfsStreamWrapperUnregisterTestCase extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Unregistering a registered URL wrapper.
+     *
+     * @test
+     */
+    public function unregisterRegisteredUrlWrapper()
+    {
+        vfsStreamWrapper::register();
+        vfsStreamWrapper::unregister();
+        $this->assertNotContains(vfsStream::SCHEME, stream_get_wrappers());
+    }
+
+    /**
+     * Unregistering a third party wrapper for vfs:// fails.
+     * 
+     * @test
+     * @expectedException org\bovigo\vfs\vfsStreamException
+     * @runInSeparateProcess
+     */
+    public function unregisterThirdPartyVfsScheme()
+    {
+        // Unregister possible registered URL wrapper. 
+        vfsStreamWrapper::unregister();
+
+        $mock = $this->getMock('org\\bovigo\\vfs\\vfsStreamWrapper');
+        stream_wrapper_register(vfsStream::SCHEME, get_class($mock));
+        
+        vfsStreamWrapper::unregister();
+    }
+    
+    /**
+     * Unregistering when not in registered state will fail.
+     *
+     * @test
+     * @expectedException org\bovigo\vfs\vfsStreamException
+     * @runInSeparateProcess
+     */
+    public function unregisterWhenNotInRegisteredState()
+    {
+        vfsStreamWrapper::register();
+        stream_wrapper_unregister(vfsStream::SCHEME);
+        vfsStreamWrapper::unregister();
+    }
+
+    /**
+     * Unregistering while not registers won't fail.
+     *
+     * @test
+     */
+    public function unregisterWhenNotRegistered()
+    {
+        // Unregister possible registered URL wrapper. 
+        vfsStreamWrapper::unregister();
+        
+        $this->assertNotContains(vfsStream::SCHEME, stream_get_wrappers());
+        vfsStreamWrapper::unregister();
+    }
+}


### PR DESCRIPTION
It would be nice to unregister the URL wrapper again, just for the sake of restoring the global state.

I ran into that issue because of a code base which has existing tests which do register a handler for vfs:// as well and I need a sane way to reset `vfsStreamWrapper::$registered`.