### PR TITLE
Always resolve root/.. as root/ for consistency with real file system

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -231,7 +231,7 @@ class vfsStreamWrapper
             if ('.' !== $pathPart) {
                 if ('..' !== $pathPart) {
                     $newPath[] = $pathPart;
-                } else {
+                } elseif (count($newPath) > 1) {
                     array_pop($newPath);
                 }
             }

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperDirTestCase.php
@@ -401,6 +401,34 @@ class vfsStreamWrapperMkDirTestCase extends vfsStreamWrapperBaseTestCase
 
     /**
      * @test
+     * @group bug_115
+     */
+    public function accessWithExcessDoubleDotsReturnsCorrectContent()
+    {
+        $this->assertEquals('baz2',
+            file_get_contents(vfsStream::url('foo/../../../../bar/../baz2'))
+        );
+    }
+
+    /**
+     * @test
+     * @group bug_115
+     */
+    public function alwaysResolvesRootDirectoryAsOwnParentWithDoubleDot()
+    {
+        vfsStreamWrapper::getRoot()->chown(vfsStream::OWNER_USER_1);
+
+        $this->assertTrue(is_dir(vfsStream::url('foo/..')));
+        $stat = stat(vfsStream::url('foo/..'));
+        $this->assertEquals(
+            vfsStream::OWNER_USER_1,
+            $stat['uid']
+        );
+    }
+
+
+    /**
+     * @test
      * @since  0.11.0
      * @group  issue_23
      */

--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperTestCase.php
@@ -418,7 +418,7 @@ class vfsStreamWrapperTestCase extends vfsStreamWrapperBaseTestCase
     public function renameDirectoryWithDotsInTarget()
     {
         // move foo/bar to foo/baz3
-        $baz3URL = vfsStream::url('foo/../foo/baz3/.');
+        $baz3URL = vfsStream::url('foo/../baz3/.');
         $this->assertTrue(rename($this->barURL . '/.', $baz3URL));
         $this->assertFileExists($baz3URL);
         $this->assertFileNotExists($this->barURL);


### PR DESCRIPTION
This is a fix for #115 - I have not been able to establish why this suddenly presents 
on PHP 5.5 but I think potentially in earlier versions the flags being passed to 
StreamWrapper::url_stat by the internal PHP SPLInfo code were causing the error
to be hidden and a falsey value returned.

This fix makes behaviour consistent with real file systems where any .. that resolves
above the root directory is simply ignored. Eg `'root' === 'root/..' === 'root/../../../..'` etc.

I wasn't totally certain of the best place to add unit tests and the best way to structure them - ideally I would have done something like `assertSame(vfsStreamWrapper::getRoot(), some_method(vfsStream::url('root/..'))`. The tests I've added were the best I could come up with (short of extending to make vfsStreamWrapper->resolvePath a public method) but happy to do differently if you can give some pointers.