### PR TITLE
Enforce error_reporting level for phpunit suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
+         bootstrap="src/test/phpunit_bootstrap.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/test/phpunit_bootstrap.php
+++ b/src/test/phpunit_bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+error_reporting(E_ALL|E_STRICT);
+require_once(__DIR__.'/../../vendor/autoload.php');


### PR DESCRIPTION
Many of the unit tests rely on phpunit's error handler throwing exceptions from various trigger_error calls. This error handler only fires for errors matching the system error_reporting configuration.

If the user's local error_reporting is configured too low then the test suite will produce a number of false failures and false positives - expected exceptions will not be thrown and code that is expected to abort will continue execution with the error message silenced. This caught me out when contributing #116 

Add a custom bootstrap to ensure that PHP is configured to use E_ALL | E_STRICT for the duration of the test run regardless of the system default setting.