### PR TITLE
Fix uninitialized string offset in newDirectory()

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStream.php
+++ b/src/main/php/org/bovigo/vfs/vfsStream.php
@@ -346,7 +346,7 @@ class vfsStream
      */
     public static function newDirectory($name, $permissions = null)
     {
-        if ('/' === $name{0}) {
+        if ($name !== '' && '/' === $name{0}) {
             $name = substr($name, 1);
         }
 


### PR DESCRIPTION
When running on PHP 7 this caused test failures (possibly only with
high error reporting).

Fixes #120