### PR TITLE
[WIP] add support to open vfs streams with compress.zlib://vfs://path/to/file.txt

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -415,9 +415,12 @@ class vfsStreamWrapper
     public function stream_close()
     {
         if (isset($this->fp)) {
+            fseek($this->fp, 0, SEEK_END);
+            $length = ftell($this->fp);
+            rewind($this->fp);
+            $this->content->setContent(fread($this->fp, $length));
             fclose($this->fp);
             $this->fp = null;
-            $this->content->setContent(file_get_contents(sys_get_temp_dir() . '/vfs-' . md5($this->content->path())));
         }
 
         $this->content->lock($this, LOCK_UN);

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -437,6 +437,9 @@ class vfsStreamWrapper
      * This will return a file resource pointing to php://temp which allows to
      * use vfsStream with urls like compress.zlib://vfs://root/test.nbt.
      *
+     * When called from stream_select() it will still return false as this is
+     * not supported.
+     *
      * @param   int  $cast_as
      * @since   0.9.0
      * @see     https://github.com/mikey179/vfsStream/issues/3

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -683,7 +683,7 @@ class vfsStreamWrapper
      */
     public function stream_cast($cast_as)
     {
-        $this->fp = fopen(sys_get_temp_dir() . '/vfs-' . md5($this->content->path()), 'wb+');
+        $this->fp = fopen('php://temp', 'wb+');
         if ($this->content->size() > 0 ) {
             fwrite($this->fp, $this->content->getContent());
             rewind($this->fp);

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -689,7 +689,7 @@ class vfsStreamWrapper
         $this->fp = fopen('php://temp', 'wb+');
         if ($this->content->size() > 0 ) {
             fwrite($this->fp, $this->content->getContent());
-            rewind($this->fp);
+            fseek($this->fp, $this->content->getBytesRead(), SEEK_SET);
         }
 
         return $this->fp;

--- a/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamWrapper.php
@@ -445,6 +445,10 @@ class vfsStreamWrapper
      */
     public function stream_cast($cast_as)
     {
+        if (STREAM_CAST_FOR_SELECT === $cast_as) {
+            return false;
+        }
+
         $this->fp = fopen('php://temp', 'wb+');
         if ($this->content->size() > 0 && false !== $this->fp) {
             fwrite($this->fp, $this->content->getContent());

--- a/src/test/php/org/bovigo/vfs/StreamCastTestCase.php
+++ b/src/test/php/org/bovigo/vfs/StreamCastTestCase.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of vfsStream.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package  org\bovigo\vfs
+ */
+namespace org\bovigo\vfs;
+/**
+ * Test for stream_cast, e.g. compress.zlib://vfs://root/test.nbt.
+ *
+ * @group  issue_125
+ */
+class StreamCastTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @type  \org\bovigo\vfs\vfsStreamDirectory
+     */
+    private $root;
+
+    /**
+     * set up test environment
+     */
+    public function setUp()
+    {
+        $this->root = vfsStream::setup('root');
+    }
+
+    /**
+     * @test
+     */
+    public function canUseCompressZlibInConjunctionWithVfsUrl()
+    {
+        file_put_contents('compress.zlib://vfs://root/test.nbt', 'barbaz');
+        $this->assertEquals(
+                'barbaz',
+                file_get_contents('compress.zlib://vfs://root/test.nbt')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function canOpenTwoCompressZlibUrlsAtTheSameTime()
+    {
+        $file1 = fopen('compress.zlib://vfs://root/test.nbt', 'wb+');
+        $file2 = fopen('compress.zlib://vfs://root/other.nbt', 'wb+');
+        fwrite($file2, 'Yippie ki-yay');
+        fwrite($file1, 'barbaz');
+        fclose($file2);
+        fclose($file1);
+        $this->assertEquals(
+                'barbaz',
+                file_get_contents('compress.zlib://vfs://root/test.nbt')
+        );
+        $this->assertEquals(
+                'Yippie ki-yay',
+                file_get_contents('compress.zlib://vfs://root/other.nbt')
+        );
+
+    }
+}


### PR DESCRIPTION
This adds support to open vfs streams using `compress.zlib://` as a prefix as described in #121. ~~However, it involves writing to disk as the vfsStream wrapper must return a file resource on its `stream_cast` method. I tried using `php://memory` first, but this resulted in a similar error message. Writing to the real file system kind of defeats the purpose of vfsStream of having no file system interaction at all. However, vfsStream could take care of removing such temporary files on its own (not implemented yet), so for the user there would be no difference at all, even though such operations might be a bit slower.~~

Update: using `php://temp` works. This solves the problem of having an interaction with the disk - PHP itself will take care of this in case a certain threshold is reached, so vfsStream doesn't have to take care of this. Additionally, this only applies to large files, but most likely not to the overwhelming majority of file sizes in unit tests.

With the current patch, this example code works:
```php
$root = vfsStream::setup("root");
file_put_contents('compress.zlib://vfs://root/test.nbt', 'barbaz');
// displays string(6) "barbaz"
var_dump(file_get_contents('compress.zlib://vfs://root/test.nbt')); 
```


