### PR TITLE
Bugfix #134 - save names of childrens as string (type safe)

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamAbstractContent.php
@@ -76,7 +76,7 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
      */
     public function __construct($name, $permissions = null)
     {
-        $this->name = $name;
+        $this->name = "{$name}";
         $time       = time();
         if (null === $permissions) {
             $permissions = $this->getDefaultPermissions() & ~vfsStream::umask();
@@ -115,7 +115,7 @@ abstract class vfsStreamAbstractContent implements vfsStreamContent
      */
     public function rename($newName)
     {
-        $this->name = $newName;
+        $this->name = "{$newName}";
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamDirectoryIssue134TestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamDirectoryIssue134TestCase.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * Project: vfsStream
+ * User: Sebastian Hopfe
+ * Date: 14.07.16
+ * Time: 14:07
+ */
+
+namespace org\bovigo\vfs;
+
+
+class vfsStreamDirectoryIssue134TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * access to root directory
+     *
+     * @var  vfsStreamDirectory
+     */
+    protected $rootDirectory;
+
+    /**
+     * set up test environment
+     */
+    public function setUp()
+    {
+        $this->rootDirectory = vfsStream::newDirectory('/');
+        $this->rootDirectory->addChild(vfsStream::newDirectory('var/log/app'));
+
+    }
+
+    /**
+     * Test: should save directory name as string internal
+     *
+     * @small
+     */
+    public function testShouldSaveDirectoryNameAsStringInternal()
+    {
+        $dir = $this->rootDirectory->getChild('var/log/app');
+
+        $dir->addChild(vfsStream::newDirectory(80));
+
+        static::assertNotNull($this->rootDirectory->getChild('var/log/app/80'));
+    }
+
+
+
+    /**
+     * Test: should rename directory name as string internal
+     *
+     * @small
+     */
+    public function testShouldRenameDirectoryNameAsStringInternal()
+    {
+        $dir = $this->rootDirectory->getChild('var/log/app');
+
+        $dir->addChild(vfsStream::newDirectory(80));
+
+        $child = $this->rootDirectory->getChild('var/log/app/80');
+        $child->rename(90);
+
+        static::assertNotNull($this->rootDirectory->getChild('var/log/app/90'));
+    }
+}


### PR DESCRIPTION
Pull Request for solving #134 / save names of childrens as string / add testcase

 - fixes #134 
