### PR TITLE
Test against the current hhvm version and php 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: php
 
 php:
-  - hhvm
+  - 7.1
   - 7.0
   - 5.6
   - 5.3
@@ -10,7 +10,15 @@ php:
   - 5.5
 
 matrix:
+  fast_finish: true
+  include:
+    # test against the latest HHVM version by using a newer image
+    - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Use edge image until the next travis CI stable image update
   allow_failures:
+    - php: 7.1
     - php: hhvm
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
       dist: trusty
       group: edge # Use edge image until the next travis CI stable image update
   allow_failures:
-    - php: 7.1
     - php: hhvm
 
 install:


### PR DESCRIPTION
This provides the current HHVM version (3.17.2 as of this PR) and will track with each release (i.e. will be 3.18 when 3.18 is released). Additionally adds php 7.1 to testing.

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change to container based Trusty after 1Q17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/