### PR TITLE
Skip test if PHP integer is too small (i.e. 32-bit PHP environment)

### DIFF
--- a/src/test/php/org/bovigo/vfs/vfsStreamWrapperLargeFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamWrapperLargeFileTestCase.php
@@ -42,6 +42,10 @@ class vfsStreamWrapperLargeFileTestCase extends \PHPUnit_Framework_TestCase
      */
     public function hasLargeFileSize()
     {
+        if (PHP_INT_MAX == 2147483647) {
+            $this->markTestSkipped('Requires 64-bit version of PHP');
+        }
+
         $this->assertEquals(
                 100 * 1024 * 1024 * 1024,
                 filesize($this->largeFile->url())


### PR DESCRIPTION
Fixes #147.