### PR TITLE
Seeking before beginning of file should fail

### DIFF
--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -52,29 +52,28 @@ abstract class SeekableFileContent implements FileContent
      */
     public function seek($offset, $whence)
     {
-        $old_offset = $this->offset;
+        $newOffset = $this->offset;
         switch ($whence) {
             case SEEK_CUR:
-                $this->offset += $offset;
+                $newOffset += $offset;
                 break;
 
             case SEEK_END:
-                $this->offset = $this->size() + $offset;
+                $newOffset = $this->size() + $offset;
                 break;
 
             case SEEK_SET:
-                $this->offset = $offset;
+                $newOffset = $offset;
                 break;
 
             default:
                 return false;
         }
         
-        if ($this->offset<0) {
-            $this->offset = $old_offset;
+        if ($newOffset<0) {
             return false;
         }
-
+        $this->offset = $newOffset;
         return true;
     }
 

--- a/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
+++ b/src/main/php/org/bovigo/vfs/content/SeekableFileContent.php
@@ -52,24 +52,30 @@ abstract class SeekableFileContent implements FileContent
      */
     public function seek($offset, $whence)
     {
+        $old_offset = $this->offset;
         switch ($whence) {
             case SEEK_CUR:
                 $this->offset += $offset;
-                return true;
+                break;
 
             case SEEK_END:
                 $this->offset = $this->size() + $offset;
-                return true;
+                break;
 
             case SEEK_SET:
                 $this->offset = $offset;
-                return true;
+                break;
 
             default:
                 return false;
         }
+        
+        if ($this->offset<0) {
+            $this->offset = $old_offset;
+            return false;
+        }
 
-        return false;
+        return true;
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
@@ -129,8 +129,17 @@ class vfsStreamFileTestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->file->getBytesRead());
         $this->assertTrue($this->file->seek(2, SEEK_END));
         $this->assertEquals(2, $this->file->getBytesRead());
-        $this->assertFalse($this->file->seek(-1, SEEK_SET),'Seek before beginning of file');
-        $this->assertEquals(2, $this->file->getBytesRead());
+    }
+
+    /**
+     * test seeking to offset before the beginning of the file
+     *
+     * @test
+     */
+    public function seekEmptyFileBeforeBeginning()
+    {
+        $this->assertFalse($this->file->seek(-5, SEEK_SET),'Seek before beginning of file');
+        $this->assertEquals(0, $this->file->getBytesRead());
     }
 
     /**
@@ -160,9 +169,28 @@ class vfsStreamFileTestCase extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->file->seek(2, SEEK_END));
         $this->assertEquals('', $this->file->readUntilEnd());
         $this->assertEquals(11, $this->file->getBytesRead());
-        $this->assertFalse($this->file->seek(-35, SEEK_SET),'Seek before beginning of file');
-        $this->assertEquals('', $this->file->readUntilEnd());
-        $this->assertEquals(11, $this->file->getBytesRead());
+    }
+
+    /**
+     * test seeking to offset before the beginning of the file
+     *
+     * @test
+     */
+    public function seekFileBeforeBeginning()
+    {
+        $this->file->setContent('foobarbaz');
+        $this->assertFalse($this->file->seek(-5, SEEK_SET),'Seek before beginning of file');
+        $this->assertEquals(0, $this->file->getBytesRead());
+        $this->assertTrue($this->file->seek(2, SEEK_CUR));
+        $this->assertFalse($this->file->seek(-5, SEEK_SET),'Seek before beginning of file');
+        $this->assertEquals(2, $this->file->getBytesRead());
+        $this->assertEquals('obarbaz', $this->file->readUntilEnd());
+        $this->assertFalse($this->file->seek(-5, SEEK_CUR),'Seek before beginning of file');
+        $this->assertEquals(2, $this->file->getBytesRead());
+        $this->assertEquals('obarbaz', $this->file->readUntilEnd());
+        $this->assertFalse($this->file->seek(-20, SEEK_END),'Seek before beginning of file');
+        $this->assertEquals(2, $this->file->getBytesRead());
+        $this->assertEquals('obarbaz', $this->file->readUntilEnd());
     }
 
     /**

--- a/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamFileTestCase.php
@@ -129,6 +129,8 @@ class vfsStreamFileTestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $this->file->getBytesRead());
         $this->assertTrue($this->file->seek(2, SEEK_END));
         $this->assertEquals(2, $this->file->getBytesRead());
+        $this->assertFalse($this->file->seek(-1, SEEK_SET),'Seek before beginning of file');
+        $this->assertEquals(2, $this->file->getBytesRead());
     }
 
     /**
@@ -156,6 +158,9 @@ class vfsStreamFileTestCase extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->file->readUntilEnd());
         $this->assertEquals(9, $this->file->getBytesRead());
         $this->assertTrue($this->file->seek(2, SEEK_END));
+        $this->assertEquals('', $this->file->readUntilEnd());
+        $this->assertEquals(11, $this->file->getBytesRead());
+        $this->assertFalse($this->file->seek(-35, SEEK_SET),'Seek before beginning of file');
         $this->assertEquals('', $this->file->readUntilEnd());
         $this->assertEquals(11, $this->file->getBytesRead());
     }


### PR DESCRIPTION
When seeking in a file to a location before the beginning of the file,
the operation seems to succeed. While if i try to do the same with a
"real" file then the seek command will return an error.

So i changed the seek method to return false if the offset is less
than 0. This seems to solve my problem and behaves in the same
way as seeking in a real file. However I do not know if there are
situations where seeking before the beginning of the file could be
a valid use case. testing with fseek on unix fs always returns -1
when seeking past the beginning of the file. Added five test
assertions to validate this behavior.