### PR TITLE
Add rights checks when removing a file #158

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamDirectory.php
@@ -135,6 +135,10 @@ class vfsStreamDirectory extends vfsStreamAbstractContent implements vfsStreamCo
     {
         foreach ($this->children as $key => $child) {
             if ($child->appliesTo($name)) {
+                if (!$child->isWritable(vfsStream::getCurrentUser(), vfsStream::getCurrentGroup())) {
+                    return false;
+                }
+
                 $child->setParentPath(null);
                 unset($this->children[$key]);
                 $this->updateModifications();

--- a/src/test/php/org/bovigo/vfs/UnlinkTestCase.php
+++ b/src/test/php/org/bovigo/vfs/UnlinkTestCase.php
@@ -24,7 +24,7 @@ class UnlinkTestCase extends \PHPUnit_Framework_TestCase
         $structure = array('test_directory' => array('test.file' => ''));
         $root = vfsStream::setup('root', null, $structure);
         $root->getChild('test_directory')->chmod(0777);
-        $root->getChild('test_directory')->getChild('test.file')->chmod(0444);
+        $root->getChild('test_directory')->getChild('test.file')->chmod(0333);
         $this->assertTrue(@unlink(vfsStream::url('root/test_directory/test.file')));
     }
 

--- a/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
+++ b/src/test/php/org/bovigo/vfs/vfsStreamDirectoryTestCase.php
@@ -166,6 +166,9 @@ class vfsStreamDirectoryTestCase extends \PHPUnit_Framework_TestCase
         $mockChild->expects($this->once())
                   ->method('size')
                   ->will($this->returnValue(5));
+        $mockChild->expects($this->once())
+                  ->method('isWritable')
+                  ->willReturn(true);
         $this->dir->addChild($mockChild);
         $this->assertTrue($this->dir->hasChild('bar'));
         $bar = $this->dir->getChild('bar');


### PR DESCRIPTION
This pull request is linked to issue #158 , with this patch applied a not writable file can't be removed.