### PR TITLE
Fix problem with annotation

### DIFF
--- a/src/main/php/org/bovigo/vfs/vfsStreamFile.php
+++ b/src/main/php/org/bovigo/vfs/vfsStreamFile.php
@@ -90,7 +90,7 @@ class vfsStreamFile extends vfsStreamAbstractContent
      * Setting content with this method does not change the time when the file
      * was last modified.
      *
-     * @param   string]FileContent  $content
+     * @param   string|FileContent  $content
      * @return  vfsStreamFile
      * @throws  \InvalidArgumentException
      */


### PR DESCRIPTION
withContent has problem with $content annotation, it has [ instead of a | to denote either a string or FileContent type.